### PR TITLE
Add retry mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Bot setup (Rename config.example.json and edit the default values):
 * `disable_help` - If true, the default help command will be disabled
 * `hide_ips` - If true, any IP addresses in notifications or the status command will be hidden
 * `notification_channel` - Channel ID where down/up notifications will be sent
+* `retries` - How many retries to complete before flagging a server with down status
 * `role_to_mention` - Role ID which will be tagged in down/up notifications
 * `secs_between_ping` - How many seconds between each uptime check
 * `timeout` - How many seconds before a ping or HTTP request should timeout

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,7 @@
   "disable_help": false,
   "hide_ips": true,
   "notification_channel": 1234,
+  "retries": 0,
   "role_to_mention": 1234,
   "secs_between_ping": 30,
   "timeout": 5


### PR DESCRIPTION
Hi,

I'm currently monitoring services in remote places where there might be network unstability, which triggers alerts while the services are actually healthy.

I've come up with this -very- simple implementation of retries to avoid false-positives, please feel free to review and decide if it's something that can be added to the main codebase.

This however comes with a breaking change as it requires the `retries` value to be added to `config.json`.

Thanks!