### PR TITLE
Multiple mentions fix

### DIFF
--- a/cogs/monitor.py
+++ b/cogs/monitor.py
@@ -16,7 +16,7 @@ class Monitor(commands.Cog):
         self.bot = bot
         self.currently_down = {}
         self.monitor_uptime.start()
-        self.already_mentioned = false
+        self.already_mentioned = False
 
     def cog_unload(self):
         self.monitor_uptime.cancel()
@@ -43,7 +43,7 @@ class Monitor(commands.Cog):
             
             """Check if the role to mentioned has already been mentioned in this instance, if not mention it and change the bool"""
             if self.already_mentioned is False:
-                self.already_mentioned = true
+                self.already_mentioned = True
                 await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
         else:
             self.currently_down[server["address"]] = self.currently_down.get(
@@ -71,7 +71,7 @@ class Monitor(commands.Cog):
             await channel.send(embed=embed)
             """Check if the role to mentioned has already been mentioned in this instance, if not mention it and change the bool"""
             if self.already_mentioned is False:
-                self.already_mentioned = true
+                self.already_mentioned = True
                 await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
             self.currently_down.pop(server["address"])
 
@@ -84,7 +84,7 @@ class Monitor(commands.Cog):
         timeout = get_config("timeout")
         
         """Reset the already mentioned field so that a new mention can be sent if there is any update"""
-        self.already_mentioned = false
+        self.already_mentioned = False
 
         for i in get_servers():
             if i["type"] == "ping":

--- a/cogs/monitor.py
+++ b/cogs/monitor.py
@@ -16,6 +16,7 @@ class Monitor(commands.Cog):
         self.bot = bot
         self.currently_down = {}
         self.monitor_uptime.start()
+        self.already_mentioned = false
 
     def cog_unload(self):
         self.monitor_uptime.cancel()
@@ -39,7 +40,11 @@ class Monitor(commands.Cog):
             embed.add_field(name="Type", value=server["type"], inline=False)
             embed.add_field(name="Reason", value=reason, inline=False)
             await channel.send(embed=embed)
-            await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
+            
+            """Check if the role to mentioned has already been mentioned in this instance, if not mention it and change the bool"""
+            if self.already_mentioned is False:
+                self.already_mentioned = true
+                await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
         else:
             self.currently_down[server["address"]] = self.currently_down.get(
                 server["address"], 0
@@ -64,7 +69,10 @@ class Monitor(commands.Cog):
                 inline=False,
             )
             await channel.send(embed=embed)
-            await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
+            """Check if the role to mentioned has already been mentioned in this instance, if not mention it and change the bool"""
+            if self.already_mentioned is False:
+                self.already_mentioned = true
+                await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
             self.currently_down.pop(server["address"])
 
     @tasks.loop(seconds=get_config("secs_between_ping"))
@@ -74,6 +82,9 @@ class Monitor(commands.Cog):
 
         channel = self.bot.get_channel(get_config("notification_channel"))
         timeout = get_config("timeout")
+        
+        """Reset the already mentioned field so that a new mention can be sent if there is any update"""
+        self.already_mentioned = false
 
         for i in get_servers():
             if i["type"] == "ping":

--- a/cogs/monitor.py
+++ b/cogs/monitor.py
@@ -40,8 +40,10 @@ class Monitor(commands.Cog):
             embed.add_field(name="Address", value=server["address"], inline=False)
             embed.add_field(name="Type", value=server["type"], inline=False)
             embed.add_field(name="Reason", value=reason, inline=False)
-            if channel is not None:
+            try:
                 await channel.send(embed=embed)
+            except Exception:
+                print("Down notification could not be sent, please check your channel permission or your config")
             
             if self.need_to_mention is False:
                 self.need_to_mention = True
@@ -68,8 +70,10 @@ class Monitor(commands.Cog):
                 value=str(timedelta(seconds=self.currently_down[server["address"]])),
                 inline=False,
             )
-            if channel is not None:
+            try:
                 await channel.send(embed=embed)
+            except Exception:
+                print("Up notification could not be sent, please check your channel permission or your config")
             
             if self.need_to_mention is False:
                 self.need_to_mention = True
@@ -132,8 +136,11 @@ class Monitor(commands.Cog):
 
         self.currently_checking = False
 
-        if self.need_to_mention is True and channel is not None:
-            await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
+        if self.need_to_mention is True:
+            try:
+                await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
+            except Exception:
+                print("Mention could not be sent, please check your channel permission or your config")
 
     @commands.command(brief="Checks status of servers being monitored", usage="status")
     async def status(self, ctx) -> None:

--- a/cogs/monitor.py
+++ b/cogs/monitor.py
@@ -40,10 +40,17 @@ class Monitor(commands.Cog):
             embed.add_field(name="Address", value=server["address"], inline=False)
             embed.add_field(name="Type", value=server["type"], inline=False)
             embed.add_field(name="Reason", value=reason, inline=False)
+            
             try:
                 await channel.send(embed=embed)
-            except Exception:
-                print("Down notification could not be sent, please check your channel permission or your config")
+            except discord.Forbidden:
+                """Does not have permission to send or read the channel"""
+                print("Down notification could not be sent, please make sure the bot has permission to sent message to the specified channel")
+            except AttributeError:
+                """Specified channel could not be found"""
+                print("Down notification could not be sent, the specified notification channel could not be found.")
+            except Exception as e:
+                print(e)
             
             if self.need_to_mention is False:
                 self.need_to_mention = True
@@ -70,10 +77,17 @@ class Monitor(commands.Cog):
                 value=str(timedelta(seconds=self.currently_down[server["address"]])),
                 inline=False,
             )
+
             try:
                 await channel.send(embed=embed)
-            except Exception:
-                print("Up notification could not be sent, please check your channel permission or your config")
+            except discord.Forbidden:
+                """Does not have permission to send or read the channel"""
+                print("Up notification could not be sent, please make sure the bot has permission to sent message to the specified channel")
+            except AttributeError:
+                """Specified channel could not be found"""
+                print("Up notification could not be sent, the specified notification channel could not be found.")
+            except Exception as e:
+                print(e)
             
             if self.need_to_mention is False:
                 self.need_to_mention = True
@@ -139,8 +153,14 @@ class Monitor(commands.Cog):
         if self.need_to_mention is True:
             try:
                 await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
-            except Exception:
-                print("Mention could not be sent, please check your channel permission or your config")
+            except discord.Forbidden:
+                """Does not have permission to send or read the channel"""
+                print("Mention could not be sent, please make sure the bot has permission to sent message to the specified channel")
+            except AttributeError:
+                """Specified channel could not be found"""
+                print("Mention could not be sent, the specified notification channel could not be found.")
+            except Exception as e:
+                print(e)
 
     @commands.command(brief="Checks status of servers being monitored", usage="status")
     async def status(self, ctx) -> None:

--- a/cogs/monitor.py
+++ b/cogs/monitor.py
@@ -41,7 +41,6 @@ class Monitor(commands.Cog):
             embed.add_field(name="Reason", value=reason, inline=False)
             await channel.send(embed=embed)
             
-            """Check if the role to mentioned has already been mentioned in this instance, if not mention it and change the bool"""
             if self.already_mentioned is False:
                 self.already_mentioned = True
                 await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
@@ -69,10 +68,11 @@ class Monitor(commands.Cog):
                 inline=False,
             )
             await channel.send(embed=embed)
-            """Check if the role to mentioned has already been mentioned in this instance, if not mention it and change the bool"""
+            
             if self.already_mentioned is False:
                 self.already_mentioned = True
                 await channel.send(f"<@&{get_config('role_to_mention')}>", delete_after=3)
+
             self.currently_down.pop(server["address"])
 
     @tasks.loop(seconds=get_config("secs_between_ping"))
@@ -82,8 +82,7 @@ class Monitor(commands.Cog):
 
         channel = self.bot.get_channel(get_config("notification_channel"))
         timeout = get_config("timeout")
-        
-        """Reset the already mentioned field so that a new mention can be sent if there is any update"""
+
         self.already_mentioned = False
 
         for i in get_servers():


### PR DESCRIPTION
Changed the mention to once only when monitor is ran. This will prevent multiple mentions in an instance if there are multiple server down.